### PR TITLE
Enhance GitHub Actions Workflow with Manual Deployment Approval

### DIFF
--- a/.github/workflows/azure-static-web-apps-gentle-cliff-024927900.yml
+++ b/.github/workflows/azure-static-web-apps-gentle-cliff-024927900.yml
@@ -10,26 +10,51 @@ on:
       - main
 
 jobs:
-  build_and_deploy_job:
+  build_job:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     runs-on: ubuntu-latest
-    name: Build and Deploy Job
+    name: Build Job
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: true
           lfs: false
-      - name: Build And Deploy
-        id: builddeploy
+      - name: Build
+        run: |
+          npm ci
+          npm run build
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: dist
+          path: dist
+
+  deploy_job:
+    needs: build_job
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
+    runs-on: ubuntu-latest
+    name: Deploy Job
+    environment:
+      name: production
+      url: ${{ steps.deploy.outputs.webapp-url }}
+    
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: dist
+          path: dist
+      
+      - name: Deploy
+        id: deploy
         uses: Azure/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_GENTLE_CLIFF_024927900 }}
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           action: "upload"
-          app_location: "/" 
-          api_location: "" 
-          output_location: "dist" # Changed from "build" to "dist"
-          app_build_command: "npm run build" # Explicitly specify the build command
+          app_location: "dist"
+          api_location: ""
+          output_location: ""
 
   close_pull_request_job:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'


### PR DESCRIPTION
# Enhance GitHub Actions Workflow with Manual Deployment Approval

## Changes Made
- Split the existing `build_and_deploy_job` into separate `build_job` and `deploy_job`.
- Introduced a `production` environment for the `deploy_job`.
- Added artifact upload/download steps to pass built files between jobs.

## Rationale
This change addresses security concerns by introducing a manual approval step before deployment. It ensures that only authorized personnel can approve and trigger deployments to our Azure Static Web App, preventing potential abuse or unintended deployments from pull requests or unauthorized pushes.

## Benefits
1. Increased security: Deployments now require explicit approval.
2. Better control: Prevents automatic deployments from PRs or pushes by unauthorized contributors.
3. Improved workflow visibility: Separating build and deploy jobs provides clearer status updates.

## Required Follow-up Actions
1. Create a "production" environment in the GitHub repository settings.
2. Configure the "production" environment to require approval and add appropriate reviewers.

## How to Review
1. Check the workflow file for correct job separation and environment configuration.
2. Verify that the artifact upload/download steps are correctly implemented.
3. Ensure the Azure Static Web Apps deploy action is properly configured in the deploy job.

## Testing
After merging, please verify:
1. Builds trigger correctly on push and PR events.
2. The deployment job waits for approval before proceeding.
3. Only approved reviewers can trigger the deployment.

This enhancement significantly improves our deployment security and control. Please review and provide any feedback or suggestions for further improvements.